### PR TITLE
Change to handle blocked island expansions

### DIFF
--- a/src/main/java/com/hjax/kagamine/economy/BaseManager.java
+++ b/src/main/java/com/hjax/kagamine/economy/BaseManager.java
@@ -56,10 +56,18 @@ public class BaseManager {
 				Vector2d second = bases.get(j).location;
 				float dist = Game.pathing_distance(first, second);
 				if (i != j) {
-					while (Math.abs(dist) < 0.1) {
-						first = Vector2d.of(first.getX() + 1, first.getY());
-						second = Vector2d.of(second.getX() + 1, second.getY());
-						dist = Game.pathing_distance(first, second);
+					//offset positions to account for a structure blocking the position
+					int offsetX = 1;
+					while (Math.abs(dist) < 0.1 && offsetX <= 5) {
+						Vector2d offsetFirst = Vector2d.of(first.getX() + offsetX, first.getY());
+						Vector2d offsetSecond = Vector2d.of(second.getX() + offsetX, second.getY());
+						dist = Game.pathing_distance(offsetFirst, offsetSecond);
+						offsetX++;
+					}
+
+					//base is unreachable (eg island)
+					if (Math.abs(dist) < 0.1) {
+						dist = 1000 + (float)first.distance(second);
 					}
 				}
 				distances.put(new ImmutablePair<>(i, j), dist);


### PR DESCRIPTION
When Kagamine finds the distance between two bases is zero, it continually offsets the x-coordinate of each base until it doesn't equal zero.  This logic works when the zero was because of a unit blocking the location.  For blocked island bases however, this will just continually offset the x-coordinate until it's off the map and Kaga crashes.

This change now sets the distance to blocked bases to: 1000 + air distance.  This will prevent the crash and cause Kaga to expand to blocked bases last in order of closest to kaga's main.

(An ideal better solution would be to recalculate the distance when the path to the base opens)
